### PR TITLE
Force Volumes improvements Issue #13

### DIFF
--- a/Assets/Scenes/Branch.unity
+++ b/Assets/Scenes/Branch.unity
@@ -2966,53 +2966,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 988738470}
   m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1001 &999586675
-Prefab:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: 386.89
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: -141.21
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: 98fdef904bd800d4c84cbe4eb91411f7, type: 2}
-  m_IsPrefabParent: 0
---- !u!4 &999586676 stripped
-Transform:
-  m_PrefabParentObject: {fileID: 4362859785690904, guid: 98fdef904bd800d4c84cbe4eb91411f7,
-    type: 2}
-  m_PrefabInternal: {fileID: 999586675}
 --- !u!1 &1060479890
 GameObject:
   m_ObjectHideFlags: 0
@@ -3486,8 +3439,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 08c57c2659b4841439a73304a5c207dc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  target: {fileID: 999586676}
-  easing: 3
+  target: {fileID: 1262771615}
+  easing: 9.8
 --- !u!4 &1217534325
 Transform:
   m_ObjectHideFlags: 0
@@ -3500,7 +3453,7 @@ Transform:
   m_Children:
   - {fileID: 2015706256}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1225804109
 GameObject:
@@ -3669,6 +3622,11 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1255838566}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1262771615 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50,
+    type: 2}
+  m_PrefabInternal: {fileID: 2138516184}
 --- !u!1 &1265852823
 GameObject:
   m_ObjectHideFlags: 0
@@ -4022,7 +3980,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!1 &1351969745
 GameObject:
@@ -5242,20 +5200,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73e72d7b31146e64ba766a8196e5c5c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  forceMult: 8
-  forceVector: {x: 1, y: 2, z: 0}
-  OverwritesGravity: 0
   turnedOn: 1
+  forceMult: 15
+  drawAngleOfForce: 1
+  angleOfForce: 150
+  OverwritesGravity: 0
   isTimed: 1
   offTime: 2
   activeTime: 2
+  toggleMesh: 1
 --- !u!4 &1831639775
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1831639772}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -47.8, y: 3.5, z: 2.8125}
   m_LocalScale: {x: 39.375057, y: 30, z: 10}
   m_Children: []
@@ -5764,13 +5724,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 73e72d7b31146e64ba766a8196e5c5c1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  forceMult: 12
-  forceVector: {x: 0, y: 1, z: 0}
-  OverwritesGravity: 0
   turnedOn: 1
+  forceMult: 12
+  drawAngleOfForce: 0
+  angleOfForce: 0
+  OverwritesGravity: 0
   isTimed: 1
   offTime: 2
   activeTime: 2
+  toggleMesh: 1
 --- !u!1 &2008841193
 GameObject:
   m_ObjectHideFlags: 0
@@ -6306,3 +6268,45 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fac2f4d4b51951746b21c8dc99dc1db9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &2138516184
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 6.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 35.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4711316976598028, guid: f028640214710694e91e5814722cac50, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: f028640214710694e91e5814722cac50, type: 2}
+  m_IsPrefabParent: 0

--- a/Assets/Scripts/ForceVolume.cs
+++ b/Assets/Scripts/ForceVolume.cs
@@ -1,51 +1,80 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEditor;
 
 /// <summary>
-/// A trigger script for collision volumes that applies forces to objects that enter the volume.  Requires some kind of 2D collider!
+/// A trigger script for collision volumes that applies forces to objects that enter the volume. Requires some kind of 2D collider! For the volume to work, the collider component on the same object needs to be a trigger!
 /// </summary>
 public class ForceVolume : MonoBehaviour {
 
-    /// <summary>
-    /// How strong the force is in this particular volume 
-    /// </summary>
-    [Tooltip("The strength of the force in this volume")]
-    public float forceMult = 2f;
-    /// <summary>
-    /// What direction the force of this volume goes.  Should be normalized.
-    /// </summary>
-    [Tooltip("The direction of force in this volume. Will be normalized.")]
-    public Vector3 forceVector = Vector3.up;
-    /// <summary>
-    /// Should this volume overwrite the other object's gravity, or simply add to it's velocity?
-    /// </summary>
-    [Tooltip("Should the force be treated as temporary gravity, or simple velocity?")]
-    public bool OverwritesGravity = false;
+    #region variables
+
     /// <summary>
     /// Controls whether this volume will apply force to pawns or not.
     /// </summary>
-    [Tooltip("Is the volume currently applying it's forces?")]
     public bool turnedOn = true;
+    /// <summary>
+    /// How strong the force is in this particular volume 
+    /// </summary>
+    public float forceMult = 2f;
+    /// <summary>
+    /// Toggles whether or not to a ray in the scene view in the direction of this volume's force. 
+    /// </summary>
+    public bool drawAngleOfForce = false;
+    /// <summary>
+    /// The angle of the forces applied by this volume. 0 is directly upwards.
+    /// </summary>
+    public float angleOfForce = 0f;
+    /// <summary>
+    /// What directional vector the force of this volume goes.  Should be normalized.
+    /// </summary>
+    private Vector3 forceVector = Vector3.up;
+    /// <summary>
+    /// Should this volume overwrite the other object's gravity, or simply add to it's velocity?
+    /// </summary>
+    public bool OverwritesGravity = false;
     /// <summary>
     /// Controls whether the volume toggles between active and inactive on a timer
     /// </summary>
-    [Tooltip("Should this volume toggle on/off on a timer?")]
     public bool isTimed = false;
     /// <summary>
     /// The number (in seconds) between deactivating and reactivating (the inactive time)
     /// </summary>
-    [Tooltip("How long (in seconds) the volume is turned ON during a timer cycle.")]
     public float offTime = 1f;
     /// <summary>
     /// The number (in seconds) between activating and deactivating (the active time)
     /// </summary>
-    [Tooltip("How long (in seconds) the volume is turned ON during a timer cycle.")]
     public float activeTime = 1f;
     /// <summary>
     /// The timer controling toggling (used if isTimed = true)
     /// </summary>
     private float timer = 0f;
+    /// <summary>
+    /// When toggled off, should this object also disable the mesh on this object?
+    /// </summary>
+    public bool toggleMesh = true;
+
+    #endregion
+    #region EditorAdjustments
+    /// <summary>
+    /// Called every time a value in the inspector is changed.  Updates force direction information.
+    /// </summary>
+    public void OnValidate()
+    {
+        //Create a rotation based on the angle specified in the editor, and then apply it to a vector.
+        forceVector = Quaternion.AngleAxis(-angleOfForce, Vector3.forward) * Vector3.up;
+    }
+
+    /// <summary>
+    /// Called when rendering in scene view.  Draws a line in the direction of force.
+    /// </summary>
+    private void OnDrawGizmos()
+    {
+        if( drawAngleOfForce ) { Debug.DrawRay(transform.position, forceVector * 5, Color.red); }
+    }
+
+    #endregion
 
     /// <summary>
     /// Every tick, if the "is timed" option is checked, the game cycles the timer and adjusts the volume accordingly
@@ -58,11 +87,13 @@ public class ForceVolume : MonoBehaviour {
             if(timer < 0f ) {
                 turnedOn = !turnedOn;//toggle the active state
                 timer = turnedOn ? activeTime : offTime;//apply the time to the timer
-
-                GetComponent<MeshRenderer>().enabled = turnedOn;//toggle visibility of the volume
+                //toggle visibility of the volume if the option to do so is enabled
+                if( toggleMesh) GetComponent<MeshRenderer>().enabled = turnedOn;
             }
         }
     }
+
+    #region Trigger Events
 
     /// <summary>
     /// What to do when an object enters this trigger volume.  Overwrites gravity if that option is checked.
@@ -115,5 +146,50 @@ public class ForceVolume : MonoBehaviour {
                 }
             }
         }        
+    }
+
+    #endregion
+
+}
+
+/// <summary>
+/// A custom editor that allows for timer options to be hidden if the volume is not timed.
+/// </summary>
+[CustomEditor(typeof(ForceVolume))]
+public class ForceVolumeEditor : Editor
+{
+    override public void OnInspectorGUI()
+    {
+
+        var myScript = target as ForceVolume;
+
+        new SerializedObject(myScript);
+
+        myScript.turnedOn = EditorGUILayout.Toggle(new GUIContent("Turned On", "Toggles whether or not this volume currently active."), myScript.turnedOn);
+        EditorGUILayout.PrefixLabel(new GUIContent("Force Multiplier:", "How powerful the force volume is. Gravitational forces require much less power."));
+        myScript.forceMult = EditorGUILayout.Slider(myScript.forceMult, 0, 100);
+        myScript.drawAngleOfForce = EditorGUILayout.Toggle(new GUIContent("Draw Angle", "Toggles whether or not to draw a vector in the scene view that represents the angle of force."), myScript.drawAngleOfForce);
+        EditorGUILayout.PrefixLabel(new GUIContent("Angle of Force: ", "What direction should the force vector point?  0 is straight UP. Toggle 'Draw Angle' To see the angle represented in the Scene View."));
+        myScript.angleOfForce = EditorGUILayout.Slider(myScript.angleOfForce, -180, 180);
+        myScript.OverwritesGravity = EditorGUILayout.Toggle(new GUIContent("Overwrites Gravity", "When true, forces overwrite gravity. When false, they are applied separately, and normal gravity is still applied to the pawn."), myScript.OverwritesGravity);
+
+        myScript.isTimed = EditorGUILayout.Toggle(new GUIContent("Use Timer", "Allows the volume to toggle itself on for a set period of time after a set delay."), myScript.isTimed);
+
+        using( var group = new EditorGUILayout.FadeGroupScope(System.Convert.ToSingle(myScript.isTimed)) )
+        {
+            if( group.visible == true )
+            {
+                EditorGUI.indentLevel++;
+                EditorGUILayout.PrefixLabel(new GUIContent("Time Off:", "How long the volume is inactive before it is toggled back on."));
+                myScript.offTime = EditorGUILayout.Slider(myScript.offTime, 0, 100);
+                EditorGUILayout.PrefixLabel(new GUIContent("Time On:", "How long the volume is active before it is toggled back off."));
+                myScript.activeTime = EditorGUILayout.Slider(myScript.activeTime, 0, 100);
+                myScript.toggleMesh = EditorGUILayout.Toggle(new GUIContent("Toggle Visibility", "If true, the mesh on this object will be turned off while the volume is in the 'inactive' part of it's timer cycle."), myScript.toggleMesh);
+                EditorGUI.indentLevel--;
+            }
+        }
+
+        //OnValidate doesn't automatically trigger w/ custom inspectors :(
+        if( GUI.changed ) { myScript.OnValidate(); }
     }
 }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.1.0f3
+m_EditorVersion: 2017.1.1f1


### PR DESCRIPTION
+ Force Volumes now use an angle value in the inspector, which is converted into a vector internally.

+ Force Volumes now have an option to draw their angle in the scene view.

+ Force Volumes now have a custom editor that hides timer variables when not in use.

+ Improved inspector tooltips, including more verbose descriptions of certain features.  Included note that volumes must have "is trigger" checked in their collision hull to be usable.