### PR TITLE
Raft fully implemented for 3D

### DIFF
--- a/Assets/Prefabs/Environment/Raft.prefab
+++ b/Assets/Prefabs/Environment/Raft.prefab
@@ -11,6 +11,36 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1663903609221806}
   m_IsPrefabParent: 1
+--- !u!1 &1251116979140838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4059057120265570}
+  m_Layer: 8
+  m_Name: Xmax
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1651788104449206
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4201701223859126}
+  m_Layer: 8
+  m_Name: Xmin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1663903609221806
 GameObject:
   m_ObjectHideFlags: 0
@@ -22,6 +52,8 @@ GameObject:
   - component: {fileID: 33686492623555596}
   - component: {fileID: 23803321828685126}
   - component: {fileID: 114104623111870378}
+  - component: {fileID: 65151220356640716}
+  - component: {fileID: 114327138505501858}
   m_Layer: 8
   m_Name: Raft
   m_TagString: Untagged
@@ -38,8 +70,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4768175567604924}
   - component: {fileID: 23685423466113172}
-  - component: {fileID: 50241792060451496}
-  - component: {fileID: 61638508053558002}
+  - component: {fileID: 65931318036510056}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Raft
@@ -47,6 +78,32 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &4059057120265570
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1251116979140838}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.0033333, y: 19.88, z: 51.13}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4483450832768604}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4201701223859126
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1651788104449206}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.0033333, y: 19.88, z: 51.13}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4483450832768604}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4483450832768604
 Transform:
   m_ObjectHideFlags: 1
@@ -54,10 +111,12 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1663903609221806}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.71, y: -1.18, z: 0}
-  m_LocalScale: {x: 3, y: 0.25, z: 1}
+  m_LocalPosition: {x: 3.01, y: -4.97, z: -102.26}
+  m_LocalScale: {x: 3, y: 0.25, z: 2}
   m_Children:
   - {fileID: 4768175567604924}
+  - {fileID: 4059057120265570}
+  - {fileID: 4201701223859126}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -145,51 +204,30 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1663903609221806}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!50 &50241792060451496
-Rigidbody2D:
-  serializedVersion: 4
+--- !u!65 &65151220356640716
+BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1725736252427732}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
+  m_GameObject: {fileID: 1663903609221806}
   m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!61 &61638508053558002
-BoxCollider2D:
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!65 &65931318036510056
+BoxCollider:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1725736252427732}
-  m_Enabled: 1
-  m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
+  m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &114104623111870378
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -204,3 +242,15 @@ MonoBehaviour:
   waterMask:
     serializedVersion: 2
     m_Bits: 16
+--- !u!114 &114327138505501858
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1663903609221806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42cc54aaf2cb27b45aed9e4646b9957f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentNode: {fileID: 0}

--- a/Assets/Scenes/Demos/raftScene.unity
+++ b/Assets/Scenes/Demos/raftScene.unity
@@ -886,23 +886,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &270123265 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1725736252427732, guid: f432db23818ee2048bd90473f9979202,
-    type: 2}
-  m_PrefabInternal: {fileID: 2101550165}
---- !u!65 &270123268
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 270123265}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &294750599
 GameObject:
   m_ObjectHideFlags: 0
@@ -1130,35 +1113,6 @@ MonoBehaviour:
   curveRadius: 15
   left: {fileID: 1110718581}
   right: {fileID: 1806520785}
---- !u!1 &350104452 stripped
-GameObject:
-  m_PrefabParentObject: {fileID: 1663903609221806, guid: f432db23818ee2048bd90473f9979202,
-    type: 2}
-  m_PrefabInternal: {fileID: 2101550165}
---- !u!114 &350104453
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 350104452}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 42cc54aaf2cb27b45aed9e4646b9957f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  currentNode: {fileID: 2054174647}
---- !u!65 &350104454
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 350104452}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &386968478
 GameObject:
   m_ObjectHideFlags: 0
@@ -3009,20 +2963,6 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
-  m_FalloffTable:
-    m_Table[0]: 0
-    m_Table[1]: 0
-    m_Table[2]: 0
-    m_Table[3]: 0
-    m_Table[4]: 0
-    m_Table[5]: 0
-    m_Table[6]: 0
-    m_Table[7]: 0
-    m_Table[8]: 0
-    m_Table[9]: 0
-    m_Table[10]: 0
-    m_Table[11]: 0
-    m_Table[12]: 0
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
   m_ShadowRadius: 0
@@ -5095,7 +5035,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
       propertyPath: m_LocalRotation.y
-      value: 0.68391067
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
       propertyPath: m_LocalRotation.z
@@ -5103,7 +5043,7 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
       propertyPath: m_LocalRotation.w
-      value: 0.7295658
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
       propertyPath: m_RootOrder
@@ -5113,17 +5053,40 @@ Prefab:
       propertyPath: m_Name
       value: Raft (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 114327138505501858, guid: f432db23818ee2048bd90473f9979202,
+        type: 2}
+      propertyPath: currentNode
+      value: 
+      objectReference: {fileID: 2054174647}
     - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 86.3
+      propertyPath: m_LocalScale.x
+      value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 4483450832768604, guid: f432db23818ee2048bd90473f9979202, type: 2}
-      propertyPath: m_LocalScale.z
-      value: 2
+    - target: {fileID: 4059057120265570, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0.5
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 61638508053558002, guid: f432db23818ee2048bd90473f9979202, type: 2}
-    - {fileID: 50241792060451496, guid: f432db23818ee2048bd90473f9979202, type: 2}
+    - target: {fileID: 4201701223859126, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4059057120265570, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4059057120265570, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4201701223859126, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4201701223859126, guid: f432db23818ee2048bd90473f9979202, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: f432db23818ee2048bd90473f9979202, type: 2}
   m_IsPrefabParent: 0
 --- !u!1 &2123294371

--- a/Assets/Scripts/Environment/Raft.cs
+++ b/Assets/Scripts/Environment/Raft.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 /// <summary>
 /// Is the main script that controls all raft objects in the game.
 /// </summary>
+[RequireComponent(typeof(AlignWithPath))]
 public class Raft : MonoBehaviour
 {
     /// <summary>
@@ -15,6 +16,10 @@ public class Raft : MonoBehaviour
     /// The direction of gravity applied when not colliding with water.
     /// </summary>
     private Vector3 gravity = Vector3.down;
+    /// <summary>
+    /// the velocity that is added to the raft every frame to determine movement.
+    /// </summary>
+    private Vector3 velocity;
     /// <summary>
     /// Holds a reference to the player object.
     /// </summary>
@@ -27,27 +32,38 @@ public class Raft : MonoBehaviour
     /// Which layers we want the raft to collide with.
     /// </summary>
     public LayerMask waterMask;
-
     /// <summary>
     /// gets the boxCollider bounds of the object and stores it in a variable
     /// </summary>
     private BoxCollider boxCollider;
     /// <summary>
-    /// stores the left minimum value for the raft
+    /// stores the X max point for the raft
     /// </summary>
-    private Vector3 leftMin;
+    private Transform xLocalMax;
     /// <summary>
-    /// stores the right minimum value for the raft
+    /// stores the X min point for the raft
     /// </summary>
-    private Vector3 rightMin;
+    private Transform xLocalMin;
     /// <summary>
     /// stores the centerpoint to the raft
     /// </summary>
-    private Vector3 centerMin;
+    private Vector3 centerPoint;
     /// <summary>
     /// stores the distance of half the height of the raft
     /// </summary>
     private float halfH;
+    /// <summary>
+    /// stores the position of the raft every frame while its in water, if it goes off of water, it holds the last position of the raft while it was in the water.
+    /// </summary>
+    private Vector3 lastPointInWater;
+    /// <summary>
+    /// stores the position of the raft when it moves off of the water.
+    /// </summary>
+    private Vector3 offWaterPoint;
+    /// <summary>
+    /// is true when the raft is on the water and false when it moves off of the water.
+    /// </summary>
+    private bool isCompletelyOnWater;
 
     /// <summary>
     /// gets the bounds of the object and then calculates the half height for it and stores both in a variable
@@ -55,19 +71,21 @@ public class Raft : MonoBehaviour
     void Start()
     {
         boxCollider = GetComponent<BoxCollider>();
-        halfH = Mathf.Abs(boxCollider.bounds.center.y - boxCollider.bounds.min.y);
+        halfH = boxCollider.bounds.extents.y;
+        xLocalMax = this.transform.GetChild(1);
+        xLocalMin = this.transform.GetChild(2);
     }
 
     /// <summary>
-    /// updates gravity every frame if not colliding with water. Updates horizontal velocity every frame if the player "isAttached" to the raft
+    /// Updates gravity every frame if not colliding with water.
+    /// Updates horizontal velocity every frame if the player "isAttached" to the raft.
     /// </summary>
     void LateUpdate()
     {
         CalculateBounds();
-        // is true when colliding with water, else false
         if (isInWater == false)
-        {
-            if (Physics.Raycast(centerMin, Vector3.down, halfH, waterMask))
+        {  
+            if (Physics.Raycast(centerPoint, Vector3.down, halfH, waterMask))
             {
                 isInWater = true;
             }
@@ -75,7 +93,6 @@ public class Raft : MonoBehaviour
             {
                 transform.position += gravity * Time.deltaTime;
             }
-
         }
 
         // is true when the player is attached to the raft
@@ -84,7 +101,6 @@ public class Raft : MonoBehaviour
             // applies velocity to the raft based upon the player
             transform.position += DetermineHorizontalMovement();
         }
-
     }
 
     /// <summary>
@@ -93,54 +109,120 @@ public class Raft : MonoBehaviour
     private void CalculateBounds()
     {
         boxCollider = this.GetComponent<BoxCollider>();
-        leftMin = new Vector3(boxCollider.bounds.min.x, boxCollider.bounds.center.y, boxCollider.bounds.center.z);
-        rightMin = new Vector3(boxCollider.bounds.max.x, boxCollider.bounds.center.y, boxCollider.bounds.center.z);
-        centerMin = boxCollider.bounds.center;
+        centerPoint = boxCollider.bounds.center;
     }
+
     /// <summary>
-    /// Determines the rafts horizontal movement if it is touching water. The raft casts rays from its left minimum y position and right minimum y position to determine if it can move in that direction initially.
+    /// Determines the rafts horizontal movement if it is touching water.
+    /// The raft casts rays from its minimum x position and maximum x position to determine if it can move in that direction initially.
     /// </summary>
     /// <returns>How much velocity to add to the raft.</returns>
     private Vector3 DetermineHorizontalMovement()
     {
-
+        // gets and stores the velocity of the player for that frame
         Vector3 raftWorldVelocity = new Vector3(pawn.worldSpace.x, 0, pawn.worldSpace.z);
-        float playerX = pawn.velocity.x;
+        velocity = raftWorldVelocity;
 
-        Vector3 velocity = raftWorldVelocity;
+        // determines to either check edges or check movement based on last frame's raycasts.
+        if(isCompletelyOnWater)
+        {
+            CheckEdges();
+        } else
+        {
+            CheckMovement();
+        }
+        return velocity;
+    }
 
+    private void CheckMovement()
+    {
+        // stores the Vector3 distance between the last point it was on water and the point of where it is off the water at.
+        Vector3 offDistance = offWaterPoint - lastPointInWater;
+        // grabs the last position on water to create an imaginary point in space with the following IF statement.
+        Vector3 imaginaryWaterPoint = lastPointInWater;
+        // moves the imaginary point further down the line to sandwich the lastPositionInWater point 
+        if (Mathf.Sign(offDistance.x) >= 0)
+        {
+            imaginaryWaterPoint.x += 1;
+        }
+        else
+        {
+            imaginaryWaterPoint.x -= 1;
+        }
+        if (Mathf.Sign(offDistance.z) >= 0)
+        {
+            imaginaryWaterPoint.z += 1;
+        }
+        else
+        {
+            imaginaryWaterPoint.z -= 1;
+        }
+
+        // stores where the raft wants to move this frame to stay aligned to player
+        Vector3 nextFramePosition = centerPoint + velocity;
+        // calculates and stores the distance that the raft needs to move to get back on water.
+        float returnDistance = CalcDistance(offDistance);
+        // stores the distance between the off water point and the imaginary point.
+        float imaginaryDistance = CalcDistance(offWaterPoint - imaginaryWaterPoint);
+        // stores the distance between the off water point and the future position
+        float currentDistance = CalcDistance(offWaterPoint - nextFramePosition);
+        // stores the distance between the imaginary point and the future position
+        float currentDistanceFromImaginary = CalcDistance(imaginaryWaterPoint - nextFramePosition);
+        // checks to see if the raft is moving towards the water
+        if (currentDistanceFromImaginary > imaginaryDistance)
+        {
+            // checks to see if the raft will be completely back on water next frame.
+            if (returnDistance / imaginaryDistance <= currentDistance / imaginaryDistance)
+            {
+                isCompletelyOnWater = true;
+            }
+        }
+        else
+        {
+            velocity.x = 0;
+            velocity.z = 0;
+        }
+    }
+
+    /// <summary>
+    /// calculates the distance between two points in space and returns that distance as a float.
+    /// </summary>
+    /// <param name="distance"> the Vector3 distance between two points </param>
+    /// <returns></returns>
+    private float CalcDistance(Vector3 distance)
+    {
+        float xDistance = distance.x;
+        float zDistance = distance.z;
+        float returnDistance = Mathf.Sqrt((xDistance * xDistance) + (zDistance * zDistance));
+
+        return returnDistance;
+    }
+
+    /// <summary>
+    /// checks to see if both edges of the raft are on water.
+    /// </summary>
+    private void CheckEdges()
+    {
         /*
         casts a ray downwards
         if the ray does not collide with water and the player is moving left
         stop the rafts horizontal movement
         */
-        if (!Physics.Raycast(leftMin, Vector3.down, 1, waterMask))
+        if (!Physics.Raycast(xLocalMax.position, Vector3.down, halfH, waterMask) || !Physics.Raycast(xLocalMin.position, Vector3.down, halfH, waterMask))
         {
-            Debug.DrawRay(leftMin, Vector3.down, Color.green, 5);
-            if (pawn.velocity.x > 0)
-            {
-                velocity.x = 0;
-                velocity.z = 0;
-            }
-        }
+            // TODO
+            offWaterPoint = centerPoint;
+            velocity.x = 0;
+            velocity.z = 0;
+            isCompletelyOnWater = false;
 
-        /*
-        casts a ray downwards
-        if the ray does not collide with water and the player is moving right
-        stop the rafts horizontal movement
-        */
-        if( !Physics.Raycast(rightMin, Vector3.down, 1, waterMask))
+        } else
         {
-            Debug.DrawRay(rightMin, Vector3.down, Color.green, 5);
-            if (pawn.velocity.x < 0)
-            {
-                velocity.x = 0;
-                velocity.z = 0;
-            }
+            lastPointInWater = centerPoint;
         }
-
-        return velocity;
+        
     }
+
     /// <summary>
     /// This method is called to attach the raft to a player.
     /// </summary>
@@ -150,6 +232,7 @@ public class Raft : MonoBehaviour
         pawn = player;
         transform.rotation = player.GetComponent<Transform>().rotation;
     }
+
     /// <summary>
     /// This method detaches the raft from a PlayerController.
     /// </summary>

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.2.0b8
+m_EditorVersion: 2017.1.1f1


### PR DESCRIPTION
> I reworked the Rafts script to fully work with 3D

> Rafts are now Raycasting in the correct areas to detect water edges. 3D bounds seem to calculate min and max bounds incorrectly when the object's rotation is not on 0, 90, 180, and 270. Because of this, I use empty game objects, as a child object of the raft, to determine which points in space to cast my rays from. As long as the empty game objects stay child objects of the raft, they will stay aligned with its edges. 
-Note- Feedback would be appreciated about this solution and if anyone else has ran into the same issue with bounding box calculations within the script.

> Completely reworked how the raft determines which direction to allow movement when moving back onto water in 3D space.

> The Raft Prefab was also updated to accommodate the new changes