### PR TITLE
Previewing Windows for Camera Nodes

### DIFF
--- a/Assets/Scripts/Pathing/CameraDataNode.cs
+++ b/Assets/Scripts/Pathing/CameraDataNode.cs
@@ -2,10 +2,16 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEditor;
+
 /// <summary>
 /// This component stores camera data in a GameObject. It is meant to be added to PathNode objects.
 /// </summary>
 public class CameraDataNode : MonoBehaviour {
+    /// <summary>
+    /// Contains a reference to a camera for use in all forms of node GUI viewing
+    /// </summary>
+    [HideInInspector]
+    static public GameObject GUIcam;
 
     /// <summary>
     /// The raw camera data to use when looking at this object.
@@ -62,10 +68,10 @@ public class CameraDataNode : MonoBehaviour {
     /// </summary>
     public CameraData cameraData;
     /// <summary>
-    /// Determines whether or not a camera window is drawn.
+    /// Determines whether or not a camera window is drawn in the scene.
     /// </summary>
     [HideInInspector]
-    public bool drawCamera = true;
+    public bool drawSceneViewer = true;
 
     #region gizmo rendering
 
@@ -83,32 +89,48 @@ public class CameraDataNode : MonoBehaviour {
     /// <summary>
     /// Returns the vector location in worldspace where the camera node will orient the camera.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>Camera location in world space.</returns>
     public Vector3 GetCameraLocation()
     {
         Quaternion rotation = GetCameraRotation();
         Vector3 camPos = new Vector3(0, 0, -cameraData.cameraDistance);
         camPos = rotation * camPos;//Applies pitch and yaw to the camera's position relative to the node
-        camPos += transform.position;//Apply relative position to world space
+        camPos += transform.position;//Apply that relative position to world space
         return camPos;
     }
     /// <summary>
-    /// Returns the Quaternion rotation the camera node will orient the camera to.
+    /// Calculates and returns the Quaternion rotation the camera node will orient the camera to.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>Quaternion rotation for the camera.</returns>
     public Quaternion GetCameraRotation()
     {
+        /* Camera yaw (movement around the y axis (along the horizon) is calculated in two parts.  The first part is the orientation of the path node itself, and then the additional yaw offset specified by the camera node.  Both need to be added together. */
         Quaternion worldRotation = GetComponent<PathNode>().GetRotationOnCurve(.5f);
         float yawAngle = worldRotation.eulerAngles.y;
         Quaternion rotation = Quaternion.Euler(cameraData.pitchOffset, yawAngle - cameraData.yawOffset, 0);
 
         return rotation;
     }
+
+    /// <summary>
+    /// Creates a new camera to use for GUI purposes if one doesn't exist.
+    /// </summary>
+    public static void CreateGUICam()
+    {
+        /*We need a separate camera to preview the node. If it hasn't already been done in this scene, we create a new camera, and name it separate from the main camera.  Now we can move this camera around to each node when we want to preview it.  The camera is hidden in the heirarchy to keep things clean, and deleted by other functions when no longer in use.*/
+        if( GameObject.Find("NodePreviewCam") ) { CameraDataNode.GUIcam = GameObject.Find("NodePreviewCam"); } else
+        {
+            CameraDataNode.GUIcam = Instantiate(GameObject.FindGameObjectWithTag("MainCamera"));
+            CameraDataNode.GUIcam.name = "NodePreviewCam";
+            CameraDataNode.GUIcam.hideFlags = HideFlags.HideInHierarchy;
+        }
+    }
+
     #endregion
 }
 
 /// <summary>
-/// A custom editor for the camera node that will draw handles for users to manipulate the camera in the scene view and draw a camera preview window in the scene view.
+/// A custom editor for the camera node that will draw handles for users to manipulate the camera in the scene view and draw a camera preview window in the scene view.  Adds new buttons to the inspector.
 /// </summary>
 [CustomEditor(typeof(CameraDataNode))]
 public class CameraNodeSceneGUI : Editor
@@ -118,31 +140,36 @@ public class CameraNodeSceneGUI : Editor
     /// </summary>
     CameraDataNode camNode;
     /// <summary>
-    /// Stores a camera that the editor will manipulate for preview windows.
-    /// </summary>
-    GameObject cam;
-    /// <summary>
     /// Stores the Rect component of the camera viewport window.
     /// </summary>
-    private Rect camWindow = new Rect(Screen.width - 430, Screen.height - 360, 400, 300);
+    private Rect camWindow = new Rect(Screen.width - 430, Screen.height - 360, 400, 300);//TODO: adjustable size scalar & aspect ratio?
 
     /// <summary>
     /// Called when the editor is created. Links the node the editor targets to an internal variable.
     /// </summary>
     private void OnEnable()
     {
-        camNode = (CameraDataNode)target;
+        camNode = (CameraDataNode)target;//register this editor to the script that called it
     }
     /// <summary>
-    /// Called to when the interface of the inspector is changed.  Adds 2 new buttons to activate viewing.
+    /// Called to when the interface of the inspector is changed.  Adds 2 new buttons to activate viewing windows.
     /// </summary>
     public override void OnInspectorGUI()
     {
         DrawDefaultInspector();//Make sure we have the normal camera data node inspector elements.
-        if(cam) OrientGUICamera();//Aligns the camera to the node's specifications.
+        if(CameraDataNode.GUIcam) OrientGUICamera();//Aligns the camera to the node's specifications.  This needs to be done every time a change is made so that it's updated for the editor version of the viewing window
         if(GUILayout.Button(new GUIContent("View in Scene Window", "Draw a viewport window in the scene view that displays the camera node's camera view.  May take a second to respond.")) )
         {
-            camNode.drawCamera = !camNode.drawCamera;
+            camNode.drawSceneViewer = !camNode.drawSceneViewer;//toggle the variable
+            if( !camNode.drawSceneViewer )//if we're not drawing the scene-viewing window
+            {
+                if(!FindObjectOfType<CameraNodeWindow>())//if there isn't an editor window
+                {
+                    //clean up the GUI camera
+                    DestroyImmediate(CameraDataNode.GUIcam);
+                    CameraDataNode.GUIcam = null;
+                }
+            } 
         }
         if( GUILayout.Button(new GUIContent("View in Editor Window", "Opens a new editor window that displays the camera nodes' camera view.")) )
         {
@@ -156,12 +183,12 @@ public class CameraNodeSceneGUI : Editor
     private void OnSceneGUI()
     {
         //If the draw camera has been toggled on we'll create a viewport window to see the camera.
-        if( camNode.drawCamera )
+        if( camNode.drawSceneViewer )
         {
             //Draw a Window GUI element that we'llr ender the camera in
             Handles.BeginGUI();//start a 2dGUI drawing session
             int id = 0;
-            camWindow = GUI.Window(id, camWindow, DrawWindow, new GUIContent("Camera View", "A preview of what the camera will see when oriented to this camera node."));
+            camWindow = GUI.Window(id, camWindow, DrawSceneViewerWindow, new GUIContent("Camera View", "A preview of what the camera will see when oriented to this camera node."));
             Handles.EndGUI();//End the 2dGUI session
         }        
     }
@@ -169,11 +196,11 @@ public class CameraNodeSceneGUI : Editor
     /// A callback function that draws the contents of a custom GUI window.
     /// </summary>
     /// <param name="id">The ID # of the window being drawn</param>
-    void DrawWindow(int id)
+    void DrawSceneViewerWindow(int id)
     {
-        CreateGUICam();
+        CameraDataNode.CreateGUICam();
         //draw the camera's view (offsets compensate for window name bar and border)
-        Handles.DrawCamera(new Rect(0, 16, camWindow.width-1, camWindow.height - 17), cam.GetComponent<Camera>(), DrawCameraMode.Normal);
+        Handles.DrawCamera(new Rect(0, 16, camWindow.width-1, camWindow.height - 17), CameraDataNode.GUIcam.GetComponent<Camera>(), DrawCameraMode.Normal);
 
         GUI.DragWindow();//allows the window to be dragged around the scene view.
     }
@@ -183,21 +210,9 @@ public class CameraNodeSceneGUI : Editor
     void OrientGUICamera()
     {
         //place this camera where the node would place it
-        cam.transform.position = camNode.GetCameraLocation();
-        cam.transform.rotation = camNode.GetCameraRotation();
-        cam.GetComponent<Camera>().fieldOfView = camNode.cameraData.fov;
-    }
-    /// <summary>
-    /// Creates a new GUI camera if one isn't in existence
-    /// </summary>
-    void CreateGUICam()
-    {
-        /*We need a separate camera to preview this. If it hasn't already been done in this scene, we create a new camera, and name it separate from the main camera.  Now we can move this camera around to each node as a preview.*/
-        if( GameObject.Find("NodePreviewCam") ) { cam = GameObject.Find("NodePreviewCam"); } else
-        {
-            cam = Instantiate(GameObject.FindGameObjectWithTag("MainCamera"));
-            cam.name = "NodePreviewCam";
-        }
+        CameraDataNode.GUIcam.transform.position = camNode.GetCameraLocation();
+        CameraDataNode.GUIcam.transform.rotation = camNode.GetCameraRotation();
+        CameraDataNode.GUIcam.GetComponent<Camera>().fieldOfView = camNode.cameraData.fov;
     }
 }
 
@@ -206,11 +221,6 @@ public class CameraNodeSceneGUI : Editor
 /// </summary>
 public class CameraNodeWindow : EditorWindow
 {
-    /// <summary>
-    /// Stores a reference to the camera to be viewed.
-    /// </summary>
-    GameObject cam;
-
     /// <summary>
     /// Initialize the window
     /// </summary>
@@ -227,28 +237,27 @@ public class CameraNodeWindow : EditorWindow
     /// </summary>
     private void Awake()
     {
-        if(!cam) CreateGUICam();
+        if(!CameraDataNode.GUIcam ) CameraDataNode.CreateGUICam();
     }
     /// <summary>
     /// Called every frame to draw GUI elements.  Draws the camera view in the window.
     /// </summary>
     private void OnGUI()
     {
-        if( !cam ) CreateGUICam();
+        if( !CameraDataNode.GUIcam ) CameraDataNode.CreateGUICam();
         Rect camRect = new Rect(0, 0, Screen.width, Screen.height);//use the size of the window, can be dynamically resized.
-        Handles.DrawCamera(camRect, cam.GetComponent<Camera>());
+        Handles.DrawCamera(camRect, CameraDataNode.GUIcam.GetComponent<Camera>());
         Repaint();//manually repaints the window
     }
     /// <summary>
-    /// Creates a new GUI camera if one isn't in existence
+    /// Called when the window is closed.  Cleans up the GUI camera.
     /// </summary>
-    void CreateGUICam()
+    private void OnDestroy()
     {
-        /*We need a separate camera to preview this. If it hasn't already been done in this scene, we create a new camera, and name it separate from the main camera.  Now we can move this camera around to each node as a preview.*/
-        if( GameObject.Find("NodePreviewCam") ) { cam = GameObject.Find("NodePreviewCam"); } else
+        if( CameraDataNode.GUIcam )
         {
-            cam = Instantiate(GameObject.FindGameObjectWithTag("MainCamera"));
-            cam.name = "NodePreviewCam";
+            DestroyImmediate(CameraDataNode.GUIcam);//Destroy Immediate is for editor destruction, use instead of destroy
+            CameraDataNode.GUIcam = null;
         }
     }
 }


### PR DESCRIPTION
+ Added In-scene viewport windows
>windows are draggable within the scene view
>windows create a new hidden camera, and delete it when the windows close

+Added editor-window viewports
>Window can be docked and moved around freely
>uses same camera as scene windows, also deleted on window close.

+Custom editor script
>2 new buttons to activate the windows

*Slight refactoring of other code and commentary.