### PR TITLE
NPC Vision Gizmos

### DIFF
--- a/Assets/Scripts/NPCs/NPCVisionGizmo.cs
+++ b/Assets/Scripts/NPCs/NPCVisionGizmo.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// option list for drawing gizmos
+/// </summary>
+public enum NPCVisionGizmoDrawOptions
+{
+    None,
+    All,
+    OnlyThisOne
+}
+
+/// <summary>
+/// Apply this to an NPC (on the same object as a vision/detection collider) to draw their activation/vision radius in the scene view.  Requires a 3d collider, doesn't work with capsules (no capsule drawing gizmo atm)
+/// </summary>
+public class NPCVisionGizmo : MonoBehaviour {
+
+    /// <summary>
+    /// Holds the selected draw option for Gizmo Drawing.
+    /// </summary>
+    public static NPCVisionGizmoDrawOptions drawGizmos;
+
+    /// <summary>
+    /// Global gizmo drawing call.  Will draw this even when not selected.
+    /// </summary>
+    private void OnDrawGizmos()
+    {
+        if (drawGizmos == NPCVisionGizmoDrawOptions.All )
+        {
+            Gizmos.color = Color.red;//red for bad guys
+            //figure out which kind of collider is on this object and draw a representation of that collider
+            if( GetComponent<BoxCollider>() )
+            {
+                Gizmos.DrawWireCube(transform.position, GetComponent<BoxCollider>().bounds.size);
+            }else if( GetComponent<SphereCollider>() )
+            {
+                Gizmos.DrawWireSphere(transform.position, GetComponent<SphereCollider>().radius);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gizmo Drawing Call. Will only be drawn when selected.
+    /// </summary>
+    private void OnDrawGizmosSelected()
+    {
+        if( drawGizmos == NPCVisionGizmoDrawOptions.OnlyThisOne )
+        {
+            Gizmos.color = Color.red;//red for bad guys
+            //figure out which kind of collider is on this object and draw a representation of that collider
+            if( GetComponent<BoxCollider>() )
+            {
+                Gizmos.DrawWireCube(transform.position, GetComponent<BoxCollider>().bounds.size);
+            } else if( GetComponent<SphereCollider>() )
+            {
+                Gizmos.DrawWireSphere(transform.position, GetComponent<SphereCollider>().radius);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Custom editor for the NPC Vision Gizmo script that allows user to select gizmo draw options from a drop down.
+/// </summary>
+[CustomEditor(typeof(NPCVisionGizmo))]
+public class NPCVisionGizmoEditor : Editor
+{
+    /// <summary>
+    /// Called when the inspector GUI is updated
+    /// </summary>
+    public override void OnInspectorGUI()
+    {
+        base.OnInspectorGUI();//call the default GUI (shouldn't be anything but does a good job of setting up the window content)
+        
+        //we need to create a custom inspector like this because a static variable can't be serialized.  This way we manually manipulate it in the inspector and change the static variable directly.
+        NPCVisionGizmo.drawGizmos = (NPCVisionGizmoDrawOptions)EditorGUILayout.EnumPopup(new GUIContent("Gizmo Draw Options","Should gizmos be drawn on all objects with this script, only this object, or not at all?  Controls everything with this script, does not discriminate between enemy types!"), NPCVisionGizmo.drawGizmos);
+    }
+
+}

--- a/Assets/Scripts/NPCs/NPCVisionGizmo.cs.meta
+++ b/Assets/Scripts/NPCs/NPCVisionGizmo.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2bec63a00f8020649b99f7063511aa6e
+timeCreated: 1512450566
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added a simple script that draws a wireframe around an NPC representing it's "vision" or attack range.

Drop script onto any enemy, on the same sub-object that has whatever collision volume is detecting the player.

Script adds a dropdown that allows you to chose to view the collision range for this object only, all objects, or none at all.

Helps to see enemies range when level designing.

Can also be turned off and on in the gizmo tray of teh scene window.